### PR TITLE
Review swap ui pull request and chain hardcoding

### DIFF
--- a/core/data/src/main/java/com/core/data/repository/SwapRepositoryImp.kt
+++ b/core/data/src/main/java/com/core/data/repository/SwapRepositoryImp.kt
@@ -33,6 +33,8 @@ class SwapRepositoryImp @Inject constructor(
     @ApplicationContext private val context: Context,
 ): SwapRepository {
 
+    private val swapHandler: SwapHandler by lazy { SwapHandler(context) }
+
     override suspend fun getQuote(
         inputTokenAddress: String,
         outputTokenAddress: String,
@@ -83,8 +85,7 @@ class SwapRepositoryImp @Inject constructor(
             Log.d("SwapRepositoryImp", "Amount: $amount")
             Log.d("SwapRepositoryImp", "Chain ID: $chainId")
             
-            val handler = SwapHandler(context)
-            val quote = handler.getSwapQuote(
+            val quote = swapHandler.getSwapQuote(
                 fromAddress = inputTokenAddress,
                 toAddress = outputTokenAddress,
                 fromDecimals = inputTokenDecimals,
@@ -121,21 +122,50 @@ class SwapRepositoryImp @Inject constructor(
             val fromMeta = tokenMetadataList.find { it.contractAddress == inputTokenAddress }
             val toMeta = tokenMetadataList.find { it.contractAddress == outputTokenAddress }
 
-            val isFromEthAlias = (inputTokenAddress == "1" || inputTokenAddress == "10")
-            val isToEthAlias = (outputTokenAddress == "1" || outputTokenAddress == "10")
+            val fromAliasChain = inputTokenAddress.toIntOrNull()
+            val toAliasChain = outputTokenAddress.toIntOrNull()
+            val chainId = fromMeta?.chainId
+                ?: toMeta?.chainId
+                ?: fromAliasChain
+                ?: toAliasChain
+                ?: run {
+                    Log.e("SwapRepositoryImp", "Unable to resolve chainId for swap request")
+                    return@withContext "ERROR_UNSUPPORTED_CHAIN"
+                }
 
-            val fromAddress = if (isFromEthAlias) "0x0000000000000000000000000000000000000000" else (fromMeta?.contractAddress ?: inputTokenAddress)
-            val toAddress = if (isToEthAlias) "0x0000000000000000000000000000000000000000" else (toMeta?.contractAddress ?: outputTokenAddress)
+            val fromIsNativeAlias = fromAliasChain != null && !inputTokenAddress.startsWith("0x", ignoreCase = true)
+            val toIsNativeAlias = toAliasChain != null && !outputTokenAddress.startsWith("0x", ignoreCase = true)
+
+            val fromAddress = when {
+                fromMeta?.contractAddress != null -> fromMeta.contractAddress
+                fromIsNativeAlias -> "0x0000000000000000000000000000000000000000"
+                inputTokenAddress.startsWith("0x", ignoreCase = true) -> inputTokenAddress
+                else -> "0x0000000000000000000000000000000000000000"
+            }
+
+            val toAddress = when {
+                toMeta?.contractAddress != null -> toMeta.contractAddress
+                toIsNativeAlias -> "0x0000000000000000000000000000000000000000"
+                outputTokenAddress.startsWith("0x", ignoreCase = true) -> outputTokenAddress
+                else -> "0x0000000000000000000000000000000000000000"
+            }
 
             val fromDecimals = fromMeta?.decimals ?: 18
             val toDecimals = toMeta?.decimals ?: 18
-            val chainId = (fromMeta?.chainId ?: toMeta?.chainId) ?: 8453
 
-            val fromSymbol = fromMeta?.symbol ?: if (isFromEthAlias) "ETH" else ""
-            val toSymbol = toMeta?.symbol ?: if (isToEthAlias) "ETH" else ""
+            val fromSymbol = when {
+                fromMeta?.symbol != null -> fromMeta.symbol
+                fromIsNativeAlias -> nativeSymbolForChain(chainId)
+                else -> ""
+            }
 
-            val handler = SwapHandler(context)
-            handler.executeSwap(
+            val toSymbol = when {
+                toMeta?.symbol != null -> toMeta.symbol
+                toIsNativeAlias -> nativeSymbolForChain(chainId)
+                else -> ""
+            }
+            
+            swapHandler.executeSwap(
                 fromAddress = fromAddress,
                 toAddress = toAddress,
                 fromDecimals = fromDecimals,
@@ -162,3 +192,8 @@ private fun toToken(
     symbol = tokenMetadata.symbol,
     name = tokenMetadata.name
 )
+
+private fun nativeSymbolForChain(chainId: Int): String = when (chainId) {
+    137 -> "MATIC"
+    else -> "ETH"
+}

--- a/core/data/src/main/java/com/core/data/swap/SwapHandler.kt
+++ b/core/data/src/main/java/com/core/data/swap/SwapHandler.kt
@@ -3,6 +3,8 @@ package com.core.data.swap
 import android.content.Context
 import android.util.Log
 import com.core.data.BuildConfig
+import com.core.data.util.chainIdToBundler
+import com.core.data.util.chainIdToRPC
 import com.core.data.utils.GasEstimationHelper
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -21,18 +23,13 @@ import org.web3j.protocol.http.HttpService
 import org.web3j.utils.Convert
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 /**
  * Minimal 0x-based swap handler mirroring TokenLauncher behavior.
  */
 class SwapHandler(private val context: Context) {
-
-    private val walletSDK = WalletSDK(
-        context = context,
-        web3jInstance = Web3j.build(HttpService("https://base-mainnet.g.alchemy.com/v2/${BuildConfig.ALCHEMY_API}")),
-        bundlerRPCUrl = "https://api.pimlico.io/v2/8453/rpc?apikey=${BuildConfig.BUNDLER_API}"
-    )
 
     companion object {
         private const val TAG = "WM-SwapHandler"
@@ -41,7 +38,11 @@ class SwapHandler(private val context: Context) {
         private const val ETH_TOKEN_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
         private const val SWAP_FEE_BPS = 15 // 0.15%
         private const val SWAP_FEE_RECIPIENT = "0xF1F39090D2bE5010Cc1Dd633b6dCe476A38b5675"
+        private val ZEROX_SUPPORTED_CHAIN_IDS = setOf(1, 10, 137, 42161, 8453)
     }
+
+    private val web3jByChain = ConcurrentHashMap<Int, Web3j>()
+    private val walletSdkByChain = ConcurrentHashMap<Int, WalletSDK>()
 
     private val httpClient = OkHttpClient.Builder()
         .connectTimeout(30, TimeUnit.SECONDS)
@@ -52,6 +53,50 @@ class SwapHandler(private val context: Context) {
     private val moshi = Moshi.Builder()
         .add(KotlinJsonAdapterFactory())
         .build()
+
+    private fun isZeroXSupported(chainId: Int): Boolean =
+        ZEROX_SUPPORTED_CHAIN_IDS.contains(chainId)
+
+    private fun resolveRpcUrl(chainId: Int): String? = try {
+        chainIdToRPC(chainId)
+    } catch (t: Throwable) {
+        Log.e(TAG, "Unable to resolve RPC for chainId=$chainId", t)
+        null
+    }
+
+    private fun getWalletSdkForChain(chainId: Int): WalletSDK? {
+        if (!isZeroXSupported(chainId)) {
+            Log.e(TAG, "0x swap is not available on chainId=$chainId")
+            return null
+        }
+
+        val rpcUrl = resolveRpcUrl(chainId)
+        if (rpcUrl == null) {
+            Log.e(TAG, "RPC URL resolution failed for chainId=$chainId")
+            return null
+        }
+
+        val bundlerUrl = chainIdToBundler(chainId)
+        val web3j = web3jByChain.getOrPut(chainId) {
+            Web3j.build(HttpService(rpcUrl))
+        }
+
+        return walletSdkByChain.getOrPut(chainId) {
+            WalletSDK(
+                context = context,
+                web3jInstance = web3j,
+                bundlerRPCUrl = bundlerUrl
+            )
+        }.also { sdk ->
+            if (sdk.getChainId() != chainId) {
+                try {
+                    sdk.changeChain(chainId, rpcUrl, bundlerUrl)
+                } catch (t: Throwable) {
+                    Log.e(TAG, "Failed to update WalletSDK chain to $chainId", t)
+                }
+            }
+        }
+    }
 
     /**
      * Execute swap via 0x. Returns tx hash on success, or error keyword.
@@ -67,6 +112,9 @@ class SwapHandler(private val context: Context) {
         fromAmount: BigDecimal
     ): String = withContext(Dispatchers.IO) {
         try {
+            val walletSDK = getWalletSdkForChain(chainId)
+                ?: return@withContext "ERROR_UNSUPPORTED_CHAIN"
+
             val isSellingETH = isEthLike(fromAddress, fromSymbol, chainId)
             val isBuyingETH = isEthLike(toAddress, toSymbol, chainId)
 
@@ -149,7 +197,7 @@ class SwapHandler(private val context: Context) {
                 txParamsList = txList,
                 callGas = null,
                 chainId = chainId,
-                gasProvider = ::gasProvider
+                gasProvider = { userOp -> gasProvider(chainId, userOp) }
             )
 
             return@withContext when {
@@ -185,8 +233,8 @@ class SwapHandler(private val context: Context) {
         )
     }
 
-    private suspend fun gasProvider(userOp: WalletSDK.UserOperation): WalletSDK.GasEstimation {
-        val rpcUrl = "https://base-mainnet.g.alchemy.com/v2/${BuildConfig.ALCHEMY_API}"
+    private suspend fun gasProvider(chainId: Int, userOp: WalletSDK.UserOperation): WalletSDK.GasEstimation {
+        val rpcUrl = resolveRpcUrl(chainId) ?: chainIdToRPC(8453)
         return GasEstimationHelper.estimateGas(userOp, rpcUrl)
     }
 
@@ -220,6 +268,9 @@ class SwapHandler(private val context: Context) {
             Log.d(TAG, "To: $toAddress ($toSymbol, decimals: $toDecimals)")
             Log.d(TAG, "Amount: $fromAmount")
             Log.d(TAG, "Chain ID: $chainId")
+            
+            val walletSDK = getWalletSdkForChain(chainId)
+                ?: return@withContext null
             
             // Validate inputs
             if (fromAmount <= BigDecimal.ZERO) {

--- a/core/data/src/main/java/com/core/data/util/apiMapper.kt
+++ b/core/data/src/main/java/com/core/data/util/apiMapper.kt
@@ -11,12 +11,15 @@ fun chainIdToName(chainId: Int): String = when(chainId) {
     42161 -> "arb-mainnet"
     137 -> "polygon-mainnet"
     8453 -> "base-mainnet"
+    7777777 -> "zora-mainnet"
     5 -> "eth-goerli"
     else -> ""
 }
 
 fun chainIdToRPC(chainId: Int): String {
-    return "https://${chainIdToName(chainId)}.g.alchemy.com/v2/${chainToApiKey(chainIdToName(chainId))}"
+    val networkName = chainIdToName(chainId)
+    require(networkName.isNotBlank()) { "Unsupported chainId: $chainId" }
+    return "https://${networkName}.g.alchemy.com/v2/${chainToApiKey(networkName)}"
 }
 
 fun chainIdToBundler(chainId: Int): String {

--- a/feature/swap/src/main/java/com/feature/swap/SwapViewModel.kt
+++ b/feature/swap/src/main/java/com/feature/swap/SwapViewModel.kt
@@ -62,6 +62,8 @@ class SwapViewModel @Inject constructor(
     private val terminalRepository: TerminalRepository,
     ): ViewModel() {
 
+    private val supportedSwapChainIds = setOf(1, 10, 137, 42161, 8453)
+
     val walletDataState: StateFlow<WalletDataUiState> = userDataRepository.userData.map {
         WalletDataUiState.Success(it)
     }.stateIn(
@@ -153,6 +155,11 @@ class SwapViewModel @Inject constructor(
     
     fun setTokenSelectorChain(chainId: Int) {
         Log.d("SwapViewModel", "setTokenSelectorChain: chainId=$chainId")
+        if (chainId !in supportedSwapChainIds) {
+            Log.w("SwapViewModel", "Selected unsupported chain for swaps: $chainId")
+            _toastMessage.value = swapsUnsupportedMessage(chainId)
+            return
+        }
         _selectedTokenChainId.value = chainId
     }
     
@@ -565,6 +572,15 @@ class SwapViewModel @Inject constructor(
             val swapToken = convertToSwapToken(selectedAsset, groupId)
             Log.d("SwapViewModel", "Converted to SwapToken: ${swapToken.token.symbol} on chain ${swapToken.token.chainId}")
             
+            if (swapToken.token.chainId !in supportedSwapChainIds) {
+                Log.w("SwapViewModel", "Selected token on unsupported chain ${swapToken.token.chainId}")
+                _toastMessage.value = swapsUnsupportedMessage(swapToken.token.chainId)
+                if (!setAsDefault) {
+                    hideTokenOverlay()
+                }
+                return@launch
+            }
+            
             when (targetMode) {
                 TokenSelectionMode.From -> {
                     Log.d("SwapViewModel", "Updating FROM token to ${swapToken.token.symbol}")
@@ -607,6 +623,13 @@ class SwapViewModel @Inject constructor(
     fun selectToTokenAsset(tokenAsset: TokenAsset) {
         viewModelScope.launch {
             Log.d("SwapViewModel", "selectToTokenAsset: ${tokenAsset.symbol} on chain ${tokenAsset.chainId}")
+            
+            if (tokenAsset.chainId !in supportedSwapChainIds) {
+                Log.w("SwapViewModel", "Attempted to select TO token on unsupported chain ${tokenAsset.chainId}")
+                _toastMessage.value = swapsUnsupportedMessage(tokenAsset.chainId)
+                hideTokenOverlay()
+                return@launch
+            }
             
             lastFetchParams = null // Clear cached params when token changes
             val currentFromToken = _swapUIState.value.fromToken
@@ -717,6 +740,13 @@ class SwapViewModel @Inject constructor(
         viewModelScope.launch {
             Log.d("SwapViewModel", "selectFromTokenAsset: ${tokenAsset.symbol} on chain ${tokenAsset.chainId}")
             
+            if (tokenAsset.chainId !in supportedSwapChainIds) {
+                Log.w("SwapViewModel", "Attempted to select FROM token on unsupported chain ${tokenAsset.chainId}")
+                _toastMessage.value = swapsUnsupportedMessage(tokenAsset.chainId)
+                hideTokenOverlay()
+                return@launch
+            }
+            
             lastFetchParams = null // Clear cached params when token changes
             
             // Format the balance for display (showing 6 decimals max)
@@ -762,8 +792,10 @@ class SwapViewModel @Inject constructor(
             
             Log.d("SwapViewModel", "convertToSwapToken: Found ${tokensInGroup.size} tokens in group")
             
+            val supportedTokens = tokensInGroup.filter { supportedSwapChainIds.contains(it.chainId) }
+            
             // Get the token with the highest fiat balance (most valuable chain for this token)
-            val primaryToken = tokensInGroup.maxByOrNull { it.fiatAmount }
+            val primaryToken = (if (supportedTokens.isNotEmpty()) supportedTokens else tokensInGroup).maxByOrNull { it.fiatAmount }
             
             val tokenAsset = if (primaryToken != null) {
                 Log.d("SwapViewModel", "convertToSwapToken: Using primary token: ${primaryToken.symbol} on chain ${primaryToken.chainId}")
@@ -825,6 +857,19 @@ class SwapViewModel @Inject constructor(
             )
         }
     }
+
+    private fun chainDisplayName(chainId: Int): String = when (chainId) {
+        1 -> "Ethereum"
+        10 -> "Optimism"
+        137 -> "Polygon"
+        42161 -> "Arbitrum"
+        8453 -> "Base"
+        7777777 -> "Zora"
+        else -> "chain $chainId"
+    }
+
+    private fun swapsUnsupportedMessage(chainId: Int): String =
+        "Swaps on ${chainDisplayName(chainId)} are not supported yet."
 
     val searchQuery = savedStateHandle.getStateFlow(SEARCH_QUERY, "")
 

--- a/feature/swap/src/main/java/com/feature/swap/ui/ChainSelectorOverlay.kt
+++ b/feature/swap/src/main/java/com/feature/swap/ui/ChainSelectorOverlay.kt
@@ -51,12 +51,11 @@ fun ChainSelectorOverlay(
 
     // All available chains with BASE at the top
     val chains = listOf(
-        NetworkChain.BASE.chainId to "BASE",
-        NetworkChain.MAINNET.chainId to "ETHEREUM",
-        NetworkChain.OPTIMISM.chainId to "OPTIMISM",
-        NetworkChain.POLYGON.chainId to "POLYGON",
-        NetworkChain.ARBITRUM.chainId to "ARBITRUM",
-        NetworkChain.ZORA.chainId to "ZORA"
+        NetworkChain.BASE to "BASE",
+        NetworkChain.MAINNET to "ETHEREUM",
+        NetworkChain.OPTIMISM to "OPTIMISM",
+        NetworkChain.POLYGON to "POLYGON",
+        NetworkChain.ARBITRUM to "ARBITRUM"
     )
 
     Dialog(
@@ -96,15 +95,15 @@ fun ChainSelectorOverlay(
                             Spacer(modifier = Modifier.height(8.dp))
                         }
 
-                        items(chains) { (chainId, chainName) ->
+                        items(chains) { (networkChain, chainName) ->
                             ChainRow(
-                                chainId = chainId,
+                                chainId = networkChain.chainId,
                                 chainName = chainName,
-                                isSelected = selectedChainId == chainId,
+                                isSelected = selectedChainId == networkChain.chainId,
                                 primaryColor = primaryColor,
                                 secondaryColor = secondaryColor,
                                 onClick = {
-                                    onChainSelected(chainId)
+                                    onChainSelected(networkChain.chainId)
                                     onDismiss()
                                 }
                             )


### PR DESCRIPTION
Implement multi-chain support for the swap feature to allow execution on supported networks beyond Base.

The previous implementation hardcoded swap execution, RPC endpoints, and bundler URLs to the Base chain, leading to failures when users attempted swaps on other networks. This PR introduces dynamic chain resolution for `WalletSDK` and related services, ensuring that swaps are correctly processed on Ethereum, Optimism, Polygon, Arbitrum, and Base. The UI also now provides clear feedback for unsupported chains.

---
<a href="https://cursor.com/background-agent?bcId=bc-501ce338-2989-479a-a748-24c13a5ddc25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-501ce338-2989-479a-a748-24c13a5ddc25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds same-chain swap support on Ethereum, Optimism, Polygon, Arbitrum, and Base with per-chain WalletSDK/RPC resolution and UI restrictions/toasts for unsupported or cross-chain selections.
> 
> - **Backend/Data**:
>   - `SwapHandler`: Adds per-chain `WalletSDK`/`Web3j` caching, dynamic RPC/bundler resolution (`chainIdToRPC`/`chainIdToBundler`), 0x chain allowlist, chain-aware gas provider, and improved ETH/native detection; updates quote/execute flows to return standardized statuses.
>   - `SwapRepositoryImp`: Reuses a lazy `SwapHandler`, resolves `chainId` from metadata or numeric aliases, handles native token aliases/zero address, derives symbols via `nativeSymbolForChain`, and routes to chain-aware quote/execute.
> - **Util**:
>   - `apiMapper`: Adds `7777777` → `zora-mainnet`, validates supported `chainId`, and builds RPC URLs from network name.
> - **UI/ViewModel**:
>   - `SwapViewModel`: Defines `supportedSwapChainIds`, blocks unsupported chains with toasts, guards against invalid cross-chain pairs, prefers supported chains in token conversion, and wires quote fetching/execution to chain-aware repo.
> - **UI**:
>   - `ChainSelectorOverlay`: Refactors chain list to use `NetworkChain` objects and removes Zora from the selector; selection passes `networkChain.chainId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f225fecd6090a3e9ef215cb98594455e249fa44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->