### PR TITLE
Stop emitting tokens with default decimals=18 when metadata is missing

### DIFF
--- a/core/data/src/main/java/com/core/data/repository/AlchemyTokenBalanceRepository.kt
+++ b/core/data/src/main/java/com/core/data/repository/AlchemyTokenBalanceRepository.kt
@@ -52,9 +52,9 @@ class AlchemyTokenBalanceRepository @Inject constructor(
 
     override fun getCombinedTokens(): Flow<List<TokenAsset>> =
         tokenBalanceDao.getCompositeTokens().map { allCompositeTokens ->
-            // Group tokens: those with metadata by symbol, those without separately
+            // Skip tokens without metadata; defaulting decimals to 18 would
+            // misreport balances for non-18-decimal tokens (USDC, USDT, etc.).
             val tokensWithMetadata = allCompositeTokens.filter { it.tokenMetadataEntity != null }
-            val tokensWithoutMetadata = allCompositeTokens.filter { it.tokenMetadataEntity == null && it.tokenBalanceEntity != null }
             
             // Process tokens with metadata (group by symbol)
             val groupedBySymbol = tokensWithMetadata.groupBy { it.tokenMetadataEntity!!.symbol }
@@ -87,34 +87,8 @@ class AlchemyTokenBalanceRepository @Inject constructor(
                     )
                 }
             }
-            
-            // Process tokens without metadata (use contract address as identifier)
-            val assetsWithoutMetadata = tokensWithoutMetadata.map { compositeToken ->
-                val balanceEntity = compositeToken.tokenBalanceEntity!!
-                // Use default decimals of 18 for tokens without metadata
-                val decimals = 18
-                val balance = balanceEntity.tokenBalance
-                    .movePointLeft(decimals)
-                    .stripTrailingZeros()
-                    .toDouble()
-                
-                // Use shortened address as symbol/name for now
-                val shortAddress = "${balanceEntity.contractAddress.take(6)}...${balanceEntity.contractAddress.takeLast(4)}"
-                
-                TokenAsset(
-                    address = balanceEntity.contractAddress,
-                    chainId = balanceEntity.chainId,
-                    symbol = shortAddress,
-                    name = "Unknown Token",
-                    balance = balance,
-                    decimals = decimals,
-                    logoUrl = null,
-                    swappable = false
-                )
-            }
-            
-            // Combine both lists
-            assetsWithMetadata + assetsWithoutMetadata
+
+            assetsWithMetadata
         }
 
     override fun getTokensBalances(): Flow<List<TokenBalance>> =


### PR DESCRIPTION
Refs #9 — addresses the primary symptom (off-by-10¹² displayed balance for non-18-decimal tokens) on the swap-screen path.

  ## Problem
  `AlchemyTokenBalanceRepository#getCombinedTokens` was constructing a `TokenAsset` with `decimals = 18` whenever a token had a balance row but no matching `TokenMetadataEntity` in the local DB. For
  6-decimal tokens like USDC, a real balance of ~10 USDC displayed as ~10⁻¹¹ USDC.

  The home view already filters tokens without metadata via `DefaultGroupedTokenRepository`, so in practice this code path only fed the swap UI — which is exactly where the wildly wrong number was
  visible.

  ## Fix
  Drop the `assetsWithoutMetadata` branch entirely. Tokens without metadata are no longer emitted from `getCombinedTokens()` until their `TokenMetadataEntity` row is populated. Matches the home-view
  behavior and stops emitting wrong numbers.

  ## Out of scope, intentional follow-ups

  Same `decimals = 18` antipattern exists in two more places not touched by this PR:

  1. **`SwapViewModel.kt:920–928` and `:947–957`** — the `else` fallback and the catch block in `convertToSwapToken` both fabricate a `TokenAsset` with `decimals = 18` and a zero address. Fixing properly
   requires either restructuring the function to return `SwapToken?` and updating callers, or surfacing failure as a UI-level error. Worth a separate PR.

  2. **`DefaultGroupedTokenRepository.kt:79–83`** — silently skips tokens without metadata. Not strictly a bug, but amplifies the symptom. Belongs in the principled follow-up that wires
  `OnChainTokenMetadataFetcher` into the no-metadata path so non-18-decimal tokens display *correctly* rather than being hidden.

  Happy to tackle either as follow-up PRs if you want.

  ## No test added
  No existing test coverage for `AlchemyTokenBalanceRepository#getCombinedTokens` and no MockWebServer-style pattern in the repo. Happy to add one (and any necessary test infrastructure) in a follow-up
  if desired.

### To maintainers:

Can the branches get cleaned up if you accept PRs? I would assume `main` would be the main branch to build from.